### PR TITLE
Fix the `aws-no-sdk` sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.envrc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # spin-go-aws
+
+Requirements:
+
+- [Spin v2.4.+](https://github.com/fermyon/spin/releases/tag/v2.4.2)
+
+## Setting variables for the applications
+
+> Use of the new feature that allows you to substitute variables into the `allowed_outbound_hosts` value in the `spin.toml` requires at least `v2.4.+` of Spin otherwise you will get errors when running `spin up`. 
+
+Variables are defined in `spin.toml` under the `variables` table towards the top of the manifest. When developing locally you can set the variables without committing them to source by setting environment variables like `export SPIN_VARIABLE_<variable-name>="value"` in the same shell you use to run spin commands.
+
+To set the variables manually you can use this script to create a `.envrc` file and source it before running `spin up`:
+
+```shell
+cat << EOF > .envrc
+export SPIN_VARIABLE_AWS_ACCESS_KEY_ID="<insert-value-here>"
+export SPIN_VARIABLE_AWS_SECRET_ACCESS_KEY="<insert-value-here>"
+export SPIN_VARIABLE_AWS_SESSION_TOKEN="<insert-value-here>"
+export SPIN_VARIABLE_AWS_DEFAULT_REGION="<insert-value-here>"
+EOF
+source .envrc
+```
+
+If you know the usual `AWS_*` variables will already be set in your shell you can also use this:
+
+```shell
+cat << EOF > .envrc
+export SPIN_VARIABLE_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+export SPIN_VARIABLE_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+export SPIN_VARIABLE_AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN"
+export SPIN_VARIABLE_AWS_DEFAULT_REGION="us-east-1"
+EOF
+source .envrc
+```
+
+To auto-load these variables you can use a tool like direnv to automatically export these variables in your shell.
+
+```shell
+cat << 'EOF' > .envrc
+export SPIN_VARIABLE_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+export SPIN_VARIABLE_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+export SPIN_VARIABLE_AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN"
+export SPIN_VARIABLE_AWS_DEFAULT_REGION="us-east-1"
+EOF
+direnv allow
+```
+
+Another method to set variables locally is to create a `.env` file next to the `spin.toml` file and when you run `spin up` it will automatically be read as variables for your application.
+
+```shell
+cat << EOF > aws-no-sdk/.env
+aws_access_key_id="<insert-value-here>"
+aws_secret_access_key="<insert-value-here>"
+aws_session_token="<insert-value-here>"
+aws_default_region="us-east-1"
+EOF
+```

--- a/aws-no-sdk/main.go
+++ b/aws-no-sdk/main.go
@@ -8,20 +8,85 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	"github.com/fermyon/spin/sdk/go/v2/variables"
 )
 
 func init() {
-	config = AWSConfig{
-		accessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
-		secretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
-		sessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
-		region:          os.Getenv("AWS_DEFAULT_REGION"),
-		service:         "s3",
-	}
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		// read config using spin variables
+		err := initConfig()
+		if err != nil {
+			fmt.Println("Failed to read configuration:", err)
+			http.Error(w, "Internal Server Error Occurred", http.StatusInternalServerError)
+			return
+		}
+
+		// Create a new HTTP request
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://s3.%s.amazonaws.com/", config.region), nil)
+		if err != nil {
+			fmt.Println("Error creating request:", err)
+			http.Error(w, "Internal Server Error Occurred", http.StatusInternalServerError)
+			return
+		}
+
+		// Set the AWS authentication headers
+		req.Header.Set("Authorization", getAuthorizationHeader(req))
+		req.Header.Set("x-amz-date", time.Now().UTC().Format("20060102T150405Z"))
+		req.Header.Set("x-amz-security-token", config.sessionToken)
+		req.Header.Set("x-amz-content-sha256", getPayloadHash(""))
+
+		// Send the HTTP request
+		resp, err := spinhttp.Send(req)
+
+		if err != nil {
+			fmt.Println("Error sending request:", err)
+			http.Error(w, "Internal Server Error Occurred", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println("Error reading response:", err)
+			http.Error(w, "Internal Server Error Occurred", http.StatusInternalServerError)
+			return
+		}
+
+		// Parse the XML response
+		var listBucketsResponse ListBucketsResponse
+		err = xml.Unmarshal(body, &listBucketsResponse)
+		if err != nil {
+			fmt.Println("Body:", string(body))
+			fmt.Println("Error parsing XML response:", err)
+			http.Error(w, "Internal Server Error Occurred", http.StatusInternalServerError)
+			return
+		}
+
+		// Print the list of buckets
+		fmt.Println("S3 Buckets:")
+		var buckets string
+		for _, bucket := range listBucketsResponse.Buckets.Bucket {
+			buckets += bucket.Name + " "
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, buckets)
+	})
+}
+
+func main() {
+	/*
+	 *	In Spin environment, the handler function has to be wired up during the init function
+	 *  because Spin will call into the wasi export named spin_http_handle_http_request
+	 *  so we need to set the default handler during the init function which is called
+	 *  before the exported spin_http_handle_http_request function in our SDK
+	 *  spinhttp.Handle: https://github.com/fermyon/spin-go-sdk/blob/48ddef7a261725f771f987323b213b0696c655ef/http/http.go#L93
+	 *  internals.go:    https://github.com/fermyon/spin-go-sdk/blob/48ddef7a261725f771f987323b213b0696c655ef/http/internals.go#L16
+	 */
 }
 
 type AWSConfig struct {
@@ -31,8 +96,6 @@ type AWSConfig struct {
 	region          string
 	service         string
 }
-
-var config AWSConfig
 
 type ListBucketsResponse struct {
 	XMLName xml.Name `xml:"ListAllMyBucketsResult"`
@@ -51,56 +114,43 @@ type ErrorResponse struct {
 	RequestID string   `xml:"RequestId"`
 }
 
-func main() {
-	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
-		// Create a new HTTP request
-		req, err := http.NewRequest("GET", "https://s3.amazonaws.com/", nil)
-		if err != nil {
-			fmt.Println("Error creating request:", err)
-			os.Exit(1)
-		}
+/*
+ * By default, Spin's security model does not pass through environment
+ * variables from the host to the guest. The recommended way to provide
+ * configuration is via "variables" that are defined in spin.toml
+ * and can be overridden by setting an environment variable like:
+ * `export SPIN_VARIABLE_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"`
+ */
 
-		// Set the AWS authentication headers
-		req.Header.Set("Authorization", getAuthorizationHeader(req))
-		req.Header.Set("x-amz-date", time.Now().UTC().Format("20060102T150405Z"))
-		req.Header.Set("x-amz-security-token", config.sessionToken)
-		req.Header.Set("x-amz-content-sha256", getPayloadHash(""))
+var config AWSConfig
 
-		// Send the HTTP request
-		resp, err := spinhttp.Send(req)
-		if err != nil {
-			fmt.Println("Error sending request:", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		// Read the response body
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println("Error reading response:", err)
-			os.Exit(1)
-		}
-
-		// Parse the XML response
-		var listBucketsResponse ListBucketsResponse
-		err = xml.Unmarshal(body, &listBucketsResponse)
-		if err != nil {
-			fmt.Println("Body:", string(body))
-			fmt.Println("Error parsing XML response:", err)
-			os.Exit(1)
-		}
-
-		// Print the list of buckets
-		fmt.Println("S3 Buckets:")
-		var buckets string
-		for _, bucket := range listBucketsResponse.Buckets.Bucket {
-			buckets += bucket.Name + " "
-		}
-
-		w.Header().Set("Content-Type", "text/plain")
-		fmt.Fprintln(w, buckets)
-	})
+func initConfig() error {
+	accessKeyID, err := variables.Get("aws_access_key_id")
+	if err != nil {
+		return err
+	}
+	secretAccessKey, err := variables.Get("aws_secret_access_key")
+	if err != nil {
+		return err
+	}
+	sessionToken, err := variables.Get("aws_session_token")
+	if err != nil {
+		return err
+	}
+	region, err := variables.Get("aws_default_region")
+	if err != nil {
+		return err
+	}
+	config = AWSConfig{
+		accessKeyID:     accessKeyID,
+		secretAccessKey: secretAccessKey,
+		sessionToken:    sessionToken,
+		region:          region,
+		service:         "s3",
+	}
+	return nil
 }
+
 func getAuthorizationHeader(req *http.Request) string {
 	// Get the current time
 	now := time.Now().UTC()

--- a/aws-no-sdk/spin.toml
+++ b/aws-no-sdk/spin.toml
@@ -6,13 +6,24 @@ version = "0.1.0"
 authors = ["Josh Rose <joshrose@hey.com>"]
 description = ""
 
+[variables]
+aws_access_key_id = { required = true }
+aws_secret_access_key = { required = true }
+aws_session_token = { required = true }
+aws_default_region = { required = true }
+
 [[trigger.http]]
 route = "/..."
 component = "aws-no-sdk"
 
 [component.aws-no-sdk]
 source = "main.wasm"
-allowed_outbound_hosts = []
+allowed_outbound_hosts = ["https://s3.{{aws_default_region}}.amazonaws.com"]
+[component.aws-no-sdk.variables]
+aws_access_key_id = "{{aws_access_key_id}}"
+aws_secret_access_key = "{{aws_secret_access_key}}"
+aws_session_token = "{{aws_session_token}}"
+aws_default_region = "{{aws_default_region}}"
 [component.aws-no-sdk.build]
 command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
Hey Josh! Sorry I lost track of this after KubeCon EU. Finally got around to updating this sample with working code at least for the `aws-no-sdk` example. Still waiting on upstream support in Golang/Tinygo to allow us to use the full AWS SDK but I'm working on testing that out. Feel free to ask any and all the questions in the PR or shoot me a message on Discord if you want to discuss the changes.